### PR TITLE
Update to pr to allow containers to not run as root

### DIFF
--- a/templates/portal/service.yaml
+++ b/templates/portal/service.yaml
@@ -10,7 +10,7 @@ spec:
 {{- end }}
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080
   selector:
 {{ include "harbor.matchLabels" . | indent 4 }}
     component: portal

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -33,6 +33,7 @@ spec:
       - name: registry
         image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["registry", "serve", "/etc/registry/config.yml"]
         livenessProbe:
           httpGet:
             path: /
@@ -74,6 +75,7 @@ spec:
       - name: registryctl
         image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["/harbor/harbor_registryctl", "-c", "/etc/registryctl/config.yml"]
         livenessProbe:
           httpGet:
             path: /api/health


### PR DESCRIPTION
These were the changes I made to allow me to run the containers from this helm chart not as root.

Super hacky, and i'm not convinced I like it, but i'm uncertain how to integrate the changes on goharbor/harbor to the `registryctl` without breaking the CI.