### PR TITLE
removed security context if not needed

### DIFF
--- a/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -27,8 +27,10 @@ spec:
     spec:
       {{- if .Values.chartmuseum.rbac }}
       serviceAccountName: {{ template "harbor.chartmuseum-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/clair/clair-dpl.yaml
+++ b/templates/clair/clair-dpl.yaml
@@ -25,8 +25,10 @@ spec:
     spec:
       {{- if .Values.clair.rbac }}
       serviceAccountName: {{ template "harbor.clair-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -26,8 +26,10 @@ spec:
     spec:
       {{- if .Values.core.rbac }}
       serviceAccountName: {{ template "harbor.core-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/database/database-ss.yaml
+++ b/templates/database/database-ss.yaml
@@ -27,8 +27,10 @@ spec:
     spec:
       {{- if .Values.database.internal.rbac }}
       serviceAccountName: {{ template "harbor.database-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -26,8 +26,10 @@ spec:
     spec:
       {{- if .Values.jobservice.rbac }}
       serviceAccountName: {{ template "harbor.jobservice-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -32,8 +32,10 @@ spec:
     spec:
       {{- if .Values.nginx.rbac }}
       serviceAccountName: {{ template "harbor.nginx-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/notary/notary-server.yaml
+++ b/templates/notary/notary-server.yaml
@@ -26,8 +26,10 @@ spec:
     spec:
       {{- if .Values.notary.rbac }}
       serviceAccountName: {{ template "harbor.notary-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -23,8 +23,10 @@ spec:
     spec:
       {{- if .Values.portal.rbac }}
       serviceAccountName: {{ template "harbor.portal-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -26,8 +26,10 @@ spec:
     spec:
       {{- if .Values.redis.internal.rbac }}
       serviceAccountName: {{ template "harbor.redis-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -27,8 +27,10 @@ spec:
     spec:
       {{- if .Values.registry.rbac }}
       serviceAccountName: {{ template "harbor.registry-serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -584,5 +584,4 @@ psp:
     - "*"
 
 # Security Context, defines the user to run as who should be the owner of the necessary directories.
-securityContext:
-  privileged: true
+securityContext: {}


### PR DESCRIPTION
I was getting `Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field "privileged" in io.k8s.api.core.v1.PodSecurityContext` error when trying to run the chart. I've removed the default `privileged: true` from `securityContext` and made it conditionally appear in the rendered templates.